### PR TITLE
Field exclusions

### DIFF
--- a/tap_ga4/discover.py
+++ b/tap_ga4/discover.py
@@ -3,10 +3,9 @@ from functools import reduce
 
 import backoff
 import singer
-from google.analytics.data_v1beta.types import GetMetadataRequest
-from google.api_core.exceptions import (ResourceExhausted, ServerError, TooManyRequests)
 from singer import Catalog, CatalogEntry, Schema, metadata
 from singer.catalog import write_catalog
+from google.api_core.exceptions import (ResourceExhausted, ServerError, TooManyRequests)
 from google.analytics.data_v1beta.types import CheckCompatibilityRequest, GetMetadataRequest, Dimension, Metric
 
 from .sync import sleep_if_quota_reached


### PR DESCRIPTION
# Description of change
- This adds field exclusions by calling the `check_compatibility` endpoint and adding all the incompatible fields to metadata. 
- There is currently no quota limit on these calls.
- Runs for ~45 seconds during every discovery.
- Gets all dimensions and metrics, including custom.

# Manual QA steps
 - Ran discovery
 - Checked app to see field selection exclusions matched Google's [Dimension and Metric Explorer](https://ga-dev-tools.web.app/ga4/dimensions-metrics-explorer/)
 
# Risks
 - If `check_compatibility` endpoint goes down, discovery will fail.
 
# Rollback steps
 - revert this branch
