### PR TITLE
Add account_id to record and record hash

### DIFF
--- a/tap_ga4/discover.py
+++ b/tap_ga4/discover.py
@@ -79,7 +79,8 @@ def add_dimensions_to_schema(schema, dimensions):
 
 def generate_base_schema():
     return {"type": "object", "properties": {"_sdc_record_hash": {"type": "string"},
-                                             "property_id": {"type": "string"}}}
+                                             "property_id": {"type": "string"},
+                                             "account_id": {"type": "string"}}}
 
 
 
@@ -88,10 +89,10 @@ def generate_metadata(schema, dimensions, metrics, field_exclusions):
                                            replication_method=["INCREMENTAL"])
     mdata = metadata.to_map(mdata)
     mdata = reduce(lambda mdata, field_name: metadata.write(mdata, ("properties", field_name), "inclusion", "automatic"),
-                   ["_sdc_record_hash", "property_id", "date"],
+                   ["_sdc_record_hash", "property_id", "account_id", "date"],
                    mdata)
     mdata = reduce(lambda mdata, field_name: metadata.write(mdata, ("properties", field_name), "tap_ga4.group", "Report Field"),
-                   ["_sdc_record_hash", "property_id"],
+                   ["_sdc_record_hash", "property_id", "account_id"],
                    mdata)
     for dimension in dimensions:
         mdata = metadata.write(mdata, ("properties", dimension.api_name), "tap_ga4.group", dimension.category)

--- a/tests/unittests/test_sync_utils.py
+++ b/tests/unittests/test_sync_utils.py
@@ -13,7 +13,8 @@ class TestRecordHashing(unittest.TestCase):
     indicates that the primary key has been invalidated by changes.
     """
     def test_record_hash_canary(self):
-        test_record = {"property_id": "123456789"}
+        test_record = {"property_id": "123456789",
+                       "account_id": "123456"}
 
         dimension_pairs = [('achievementId', 'hi'),
                            ('campaignId', '(not set)'),
@@ -23,7 +24,7 @@ class TestRecordHashing(unittest.TestCase):
                            ('city', 'my_city'),
                            ('firstSessionDate', '20220906')]
 
-        expected_hash = "23f0156453ea07c48dc1af80dfaf7f2346da49cbc18203d89056df81819c0ddb"
+        expected_hash = "0854e5a26abcccf6990128ab5581b429698e05a6436fc09defe5a22d7f479f9e"
         self.assertEqual(expected_hash, generate_sdc_record_hash(test_record, dimension_pairs))
 
 


### PR DESCRIPTION
# Description of change
Adds account_id to the record and _sdc_record_hash. Also simplified `generate_sdc_record_hash` 

# Manual QA steps
 - ran discovery locally
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
