### PR TITLE
Update premade report names to match ga4 data api name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
+## v0.0.12
+  * Update premade report names to match GA4 Data API changes [#27](https://github.com/singer-io/tap-ga4/pull/27)
 ## v0.0.11
-  * Update field names to match GA4 Data API changes  [#26](https://github.com/singer-io/tap-ga4/pull/26)
+  * Update field names to match GA4 Data API changes [#26](https://github.com/singer-io/tap-ga4/pull/26)
 ## v0.0.10
   * Update datetime formats to account for canonicalization of datetime dimensions  [#22](https://github.com/singer-io/tap-ga4/pull/22)
 ## v0.0.9

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.0.11",
+    version="0.0.12",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/reports.py
+++ b/tap_ga4/reports.py
@@ -1,6 +1,6 @@
 PREMADE_REPORTS = [
     {
-        "name": "user_acq_first_user_default_channel_grouping_report",
+        "name": "user_acq_first_user_default_channel_group_report",
         "metrics": [
             "newUsers",
             "engagedSessions",
@@ -208,7 +208,7 @@ PREMADE_REPORTS = [
         ],
     },
     {
-        "name": "traffic_acq_session_default_channel_grouping_report",
+        "name": "traffic_acq_session_default_channel_group_report",
         "metrics": [
             "totalUsers",
             "sessions",


### PR DESCRIPTION
# Description of change
Related to #26, while we are still in alpha we should update the premade report names to match the updated google api names.  

# Manual QA steps
 - 
 
# Risks
 - The one alpha user's tables will be deselected. However, they already need to reset those tables anyways because the api names changed and they would have a column split. 
 
# Rollback steps
 - revert this branch
