### PR TITLE
Fix field exclusions test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           at: /usr/local/share/virtualenvs
       - run:
           name: 'Run Field Exclusion Test'
-          no_output_timeout: 30m
+          no_output_timeout: 60m
           command: |
             source /usr/local/share/virtualenvs/tap-ga4/bin/activate
             source /usr/local/share/virtualenvs/dev_env.sh

--- a/tests/field_exclusions/field_exclusions_test.py
+++ b/tests/field_exclusions/field_exclusions_test.py
@@ -19,7 +19,7 @@ class TestFieldExclusions(unittest.TestCase):
     
     def get_default_field_exclusions(self, client, property_id):
         
-        dimensions, metrics = get_dimensions_and_metrics(client, 0)
+        dimensions, metrics, _ = get_dimensions_and_metrics(client, 0)
 
         fields = defaultdict(list)
         for dimension in dimensions:


### PR DESCRIPTION
# Description of change
The field exclusions test uses `get_dimensions_and_metrics`. We updated that function to also return invalid metrics.
This unpacks `invalid_metrics`, which is not needed for the test.

# Manual QA steps
 - Verified test passes when all parts of tuple are unpacked
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
