### PR TITLE
pylint and discovery updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-ga4/bin/activate
             # TODO: Adjust the pylint disables
-            pylint tap_ga4 --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,missing-class-docstring'
+            pylint tap_ga4 --disable 'broad-except,broad-exception-caught,broad-exception-raised,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,missing-class-docstring'
       - slack/notify-on-failure:
           only_for_branches: main
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -27,10 +27,3 @@ class GA4DiscoveryTest(DiscoveryTest, GA4Base):
 
         So this test case is skipped.
         """
-
-    @unittest.skip("TODO Known Failure. Waiting on tap implementation.")
-    def test_replication_metadata_by_streams(self):
-        """
-        Currently the replication key is not yet decided on, and the forced-replication-method
-        is missing from metadata.
-        """


### PR DESCRIPTION
# Description of change
Update pylint disables to match new version text.  Un-skip discovery test.
Discovery test needs tap-tester update to pass:
https://github.com/stitchdata/tap-tester/pull/324

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
