### PR TITLE
Update quota sleep timeout to match googles api change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           at: /usr/local/share/virtualenvs
       - run:
           name: 'Run Integration Tests'
-          no_output_timeout: 60m
+          no_output_timeout: 70m
           command: |
             source /usr/local/share/virtualenvs/dev_env.sh
             mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
@@ -109,7 +109,7 @@ jobs:
           at: /usr/local/share/virtualenvs
       - run:
           name: 'Run Field Exclusion Test'
-          no_output_timeout: 60m
+          no_output_timeout: 70m
           command: |
             source /usr/local/share/virtualenvs/tap-ga4/bin/activate
             source /usr/local/share/virtualenvs/dev_env.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.0.19
+  * Update wait time after quota limit is reached to one hour [#42](https://github.com/singer-io/tap-ga4/pull/42)
 ## v0.0.18
   * Update cached field exclusions to match changes made in the GA4 Data API [#41](https://github.com/singer-io/tap-ga4/pull/41)
 ## v0.0.17

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.0.18",
+    version="0.0.19",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/client.py
+++ b/tap_ga4/client.py
@@ -10,8 +10,6 @@ from google.analytics.data_v1beta.types import (CheckCompatibilityRequest,
 from google.api_core.exceptions import (ResourceExhausted, ServerError,
                                         TooManyRequests)
 from google.oauth2.credentials import Credentials
-from singer import utils
-
 
 LOGGER = singer.get_logger()
 

--- a/tap_ga4/client.py
+++ b/tap_ga4/client.py
@@ -1,5 +1,4 @@
 import time
-from datetime import timedelta
 import backoff
 import singer
 from google.analytics.data_v1beta import BetaAnalyticsDataClient

--- a/tap_ga4/client.py
+++ b/tap_ga4/client.py
@@ -17,22 +17,13 @@ from singer import utils
 LOGGER = singer.get_logger()
 
 
-def seconds_to_next_hour():
-    current_utc_time = utils.now()
-    # Get a time 10 seconds past the hour to be sure we don't make another
-    # request before Google resets quota.
-    next_hour = (current_utc_time + timedelta(hours=1)).replace(minute=0, second=10, microsecond=0)
-    time_till_next_hour = (next_hour - current_utc_time).seconds
-    return time_till_next_hour
-
-
 def sleep_if_quota_reached(ex):
     if isinstance(ex, ResourceExhausted):
-        seconds = seconds_to_next_hour()
+        # Wait 1 hour for google to reset api quota
+        seconds = 3600
         LOGGER.info("Reached hourly quota limit. Sleeping %s seconds.", seconds)
         time.sleep(seconds)
     return False
-
 
 class Client:
 


### PR DESCRIPTION
# Description of change
Google updated the api to wait up until an hour to reset the quota, rather than wait until the top of the next hour. 

> [Note: All daily quotas are refreshed at midnight Pacific Standard Time. All hourly quotas are refreshed within an hour but not necessarily on the whole hour boundaries. ](https://developers.google.com/analytics/devguides/reporting/data/v1/quotas)

This pr updates the tap to wait an hour when the quota limit is hit

# Manual QA steps
 - 
 
# Risks
-
 
# Rollback steps
 - revert this branch
