### PR TITLE
Updates order of circleci build daily workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,15 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
+            - run_field_exclusions_test
+      - run_field_exclusions_test:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+            - singer-bot-github-token
+          requires:
+            - run_pylint
+            - run_unit_tests
       - build:
           context:
             - circleci-user
@@ -181,6 +190,7 @@ workflows:
             - run_pylint
             - run_unit_tests
             - run_integration_tests
+            - run_field_exclusions_test
   build_daily:
     jobs:
       - ensure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,15 +173,6 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
-            - run_field_exclusions_test
-      - run_field_exclusions_test:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-            - singer-bot-github-token
-          requires:
-            - run_pylint
-            - run_unit_tests
       - build:
           context:
             - circleci-user
@@ -190,7 +181,6 @@ workflows:
             - run_pylint
             - run_unit_tests
             - run_integration_tests
-            - run_field_exclusions_test
   build_daily:
     jobs:
       - ensure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
+            - run_field_exclusions_test
       - run_field_exclusions_test:
           context:
             - circleci-user
@@ -213,7 +214,6 @@ workflows:
           requires:
             - run_pylint
             - run_unit_tests
-            - run_integration_tests
       - build:
           context:
             - circleci-user


### PR DESCRIPTION
# Description of change
Forces field exclusions test to run before integration tests so that the field exclusion script will run before a failing integration test can block it. 

# Manual QA steps
 -  tested with current field exclusion update
 
# Risks
 - low, just a circleci update
 
# Rollback steps
 - revert this branch
