### PR TITLE
update metric fields for the ecommerce report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v0.0.28
+  * Update metric fields for the ecommerce report [#67](https://github.com/singer-io/tap-ga4/pull/71)
+
 ## v0.0.27
   * Update cached field exclusions to match changes made in the GA4 Data API [#67](https://github.com/singer-io/tap-ga4/pull/67)
 ## v0.0.26

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.0.27",
+    version="0.0.28",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/reports.py
+++ b/tap_ga4/reports.py
@@ -335,12 +335,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_name_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -351,12 +350,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_id_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -367,12 +365,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_category_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -383,12 +380,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_category_2_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -399,12 +395,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_category_3_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -415,12 +410,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_category_4_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -431,12 +425,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_category_5_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [
@@ -447,12 +440,11 @@ PREMADE_REPORTS = [
     {
         "name": "ecommerce_purchases_item_brand_report",
         "metrics": [
-            "addToCarts",
+            "itemsAddedToCart",
             "cartToViewRate",
-            "ecommercePurchases",
-            "itemPurchaseQuantity",
+            "itemsPurchased",
             "itemRevenue",
-            "itemViews",
+            "itemsViewed",
             "purchaseToViewRate",
         ],
         "dimensions": [

--- a/tap_ga4/reports.py
+++ b/tap_ga4/reports.py
@@ -338,7 +338,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -351,7 +351,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -364,7 +364,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -377,7 +377,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -390,7 +390,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -403,7 +403,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -416,7 +416,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",
@@ -429,7 +429,7 @@ PREMADE_REPORTS = [
             "itemsAddedToCart",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed"
+            "itemsViewed",
         ],
         "dimensions": [
             "date",

--- a/tap_ga4/reports.py
+++ b/tap_ga4/reports.py
@@ -336,11 +336,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_name_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -351,11 +349,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_id_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -366,11 +362,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_category_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -381,11 +375,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_category_2_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -396,11 +388,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_category_3_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -411,11 +401,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_category_4_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -426,11 +414,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_category_5_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",
@@ -441,11 +427,9 @@ PREMADE_REPORTS = [
         "name": "ecommerce_purchases_item_brand_report",
         "metrics": [
             "itemsAddedToCart",
-            "cartToViewRate",
             "itemsPurchased",
             "itemRevenue",
-            "itemsViewed",
-            "purchaseToViewRate",
+            "itemsViewed"
         ],
         "dimensions": [
             "date",


### PR DESCRIPTION
# Description of change
The pre-made report (e-commerce reports) fields became incompatible and completely broken. Updated the new metric fields.

# Manual QA steps
 - No conflicting fields appear on UI.
 - Queried using the updated metrics.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
