### PR TITLE
Add logic to checkout an old branch, reorganize code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,25 +123,62 @@ jobs:
           when: on_fail
           command: |
             echo "Committing to GitHub"
+
+            # Setup
             git config user.email "stitchintegrationdev@talend.com"
             git config user.name "CircleCI Job"
-            git checkout main
-            git checkout -b update-field-selection-$(date -I)
-            mv /root/project/tap_ga4/new_field_exclusions.json /root/project/tap_ga4/field_exclusions.json
-            OLD_VERSION=$(python setup.py --version)
-            apt install -y gawk
-            NEW_VERSION="$(python setup.py --version | gawk -F. '/[0-9]+/{$NF++;print}' OFS=.)"
-            sed -i 's/'"$OLD_VERSION"'/'"$NEW_VERSION"'/g' /root/project/setup.py
-            git commit -am "Update field exclusions"
-            git push -u origin update-field-selection-$(date -I)
+
             wget https://github.com/cli/cli/releases/download/v2.23.0/gh_2.23.0_linux_amd64.tar.gz
             tar xf gh_2.23.0_linux_amd64.tar.gz
             cp /root/project/gh_2.23.0_linux_amd64/bin/gh .
-            ./gh pr create --title "Update field selection" --body "Update cached field exclusions to match changes made in the GA4 Data API" -B main
-            export PR_NUMBER=$(./gh pr list -L 1 --json number -q .[].number)
-            sed -i '1 a\## v'"$NEW_VERSION"'\n  * Update cached field exclusions to match changes made in the GA4 Data API [#'"$PR_NUMBER"'](https://github.com/singer-io/tap-ga4/pull/'"$PR_NUMBER"')' CHANGELOG.md
-            git commit -am "Update changelog [skip-ci]"
-            git push
+
+            apt install -y gawk
+
+            bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+            # End Setup
+
+            CLJ_SCRIPT='
+            (-> (mapv clojure.string/trim *input*)
+                sort
+                last
+                (clojure.string/split (re-pattern "remotes/origin/"))
+                last
+                println)
+            '
+            # Decide if we need to checkout a new branch
+            branch_name=''
+            if ! git branch -a | grep 'remotes/origin/update-field-selection.*' > /dev/null ;
+            then
+                echo 'No remote branches found that look like `update-field-selection*`'
+                branch_name="update-field-selection-$(date -I)"
+                git checkout main
+                git checkout -b "$branch_name"
+            else
+                echo 'Found remote branches'
+                branch_name=$(git branch -a | grep 'remotes/origin/update-field-selection.*' | bb -i -e "$CLJ_SCRIPT")
+                git checkout "$branch_name"
+            fi
+
+            mv /root/project/tap_ga4/new_field_exclusions.json /root/project/tap_ga4/field_exclusions.json
+
+            if git diff --quiet tap_ga4/field_exclusions.json;
+            then
+                echo 'No diff'
+            else
+                # Commit 1: Schema changes
+                git commit -am "Update field exclusions"
+                git push -u origin "$branch_name"
+                ./gh pr create --title "Update field selection" --body "Update cached field exclusions to match changes made in the GA4 Data API" -B main
+                # Commit 2: packaging stuff
+
+                OLD_VERSION=$(python setup.py --version)
+                NEW_VERSION="$(python setup.py --version | gawk -F. '/[0-9]+/{$NF++;print}' OFS=.)"
+                PR_NUMBER=$(./gh pr list -L 1 --json number -q .[].number)
+                sed -i 's/'"$OLD_VERSION"'/'"$NEW_VERSION"'/g' /root/project/setup.py
+                sed -i '1 a\## v'"$NEW_VERSION"'\n  * Update cached field exclusions to match changes made in the GA4 Data API [#'"$PR_NUMBER"'](https://github.com/singer-io/tap-ga4/pull/'"$PR_NUMBER"')' CHANGELOG.md
+                git commit -am "Bump version, Update changelog [skip-ci]"
+                git push
+            fi
       - slack/notify-on-failure:
           only_for_branches: main
       - store_artifacts:


### PR DESCRIPTION
# Description of change
This PR adds more logic to the CI pipeline to decide if we need to open a PR with field exclusion updates.

# Manual QA steps

I forced the CI pipeline to just run the Field Exclusions step. None of that is intended to go in the final merge.

## Test Cases
### New changes, should open a PR
Here's some logs with the new `check for an existing branch` logic
```
No remote branches found that look like `update-field-selection*`
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
Switched to a new branch 'update-field-selection-2023-11-08'
```
[Source](https://app.circleci.com/pipelines/github/singer-io/tap-ga4/853/workflows/5d31909e-6c45-415a-ba79-ef76b8d4c18a/jobs/3858?invite=true#step-105-3204_60)

---

Here you can see a commit is pushed and a PR is opened. I took out some logging from `dependabot` because it's not relevant to this change. But you will see it in Circle.
```
[update-field-selection-2023-11-08 e747c42] Update field exclusions
 1 file changed, 1 insertion(+), 1 deletion(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 36 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 388 bytes | 388.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.        
remote: 
remote: Create a pull request for 'update-field-selection-2023-11-08' on GitHub by visiting:        
remote:      https://github.com/singer-io/tap-ga4/pull/new/update-field-selection-2023-11-08               
remote: 
To github.com:singer-io/tap-ga4.git
 * [new branch]      update-field-selection-2023-11-08 -> update-field-selection-2023-11-08
Branch 'update-field-selection-2023-11-08' set up to track remote branch 'update-field-selection-2023-11-08' from 'origin'.
Warning: 3 uncommitted changes

Creating pull request for update-field-selection-2023-11-08 into main in singer-io/tap-ga4

https://github.com/singer-io/tap-ga4/pull/94
```
[Source](https://app.circleci.com/pipelines/github/singer-io/tap-ga4/853/workflows/5d31909e-6c45-415a-ba79-ef76b8d4c18a/jobs/3858?invite=true#step-105-4501_44)

### No changes, no new PR is expected

Building off of the previous test run, if we just run the pipeline again, then we want the logs to note there are no changes to commit, and obviously no new PR to open.

```
Found remote branches
Branch 'update-field-selection-2023-11-08' set up to track remote branch 'update-field-selection-2023-11-08' from 'origin'.
Switched to a new branch 'update-field-selection-2023-11-08'
No diff
Found existing PR at https://github.com/singer-io/tap-ga4/pull/94, not opening another PR
```
[Source](https://app.circleci.com/pipelines/github/singer-io/tap-ga4/861/workflows/eaaee03a-b381-4be5-aa0b-232ec23b0aef/jobs/3880?invite=true#step-105-3280_89)

### New changes, no new PR is expected

Building off of the previous test run again. If we force the field exclusions file to have another change, then we want a new commit to be made, but on the old branch.

Again, in this snippet in Circle, you'll see some `dependabot` logs, but here I've left them out for clarity

```
Found remote branches
Branch 'update-field-selection-2023-11-08' set up to track remote branch 'update-field-selection-2023-11-08' from 'origin'.
Switched to a new branch 'update-field-selection-2023-11-08'
[update-field-selection-2023-11-08 813d21b] Update field exclusions
 1 file changed, 1 insertion(+), 1 deletion(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 36 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 388 bytes | 388.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.            
remote: 
To github.com:singer-io/tap-ga4.git
   b39e99c..813d21b  update-field-selection-2023-11-08 -> update-field-selection-2023-11-08
Branch 'update-field-selection-2023-11-08' set up to track remote branch 'update-field-selection-2023-11-08' from 'origin'.
Found existing PR at https://github.com/singer-io/tap-ga4/pull/94, not opening another PR
```
[Source](https://app.circleci.com/pipelines/github/singer-io/tap-ga4/862/workflows/b0184ff4-4890-4f33-9629-26864a378e0c/jobs/3882?invite=true#step-105-4182_89)


# Risks
 - Low. The existing process is much more noisy, so things can't really get worse. The only real issue is if I missed something and this doesn't improve things as much as I want them to
 
# Rollback steps
 - revert this branch
