### PR TITLE
Upgrade python version to 3.11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-3-11-dev
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-3-11-dev
 
 jobs:
   build:
@@ -22,7 +22,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-ga4
             source /usr/local/share/virtualenvs/tap-ga4/bin/activate
-            pip install 'pip==21.1.3'
+            pip install 'pip==23.3.2'
             pip install 'setuptools==60.8.2'
             pip install .[dev]
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virtualenvs/dev_env.sh
@@ -60,9 +60,8 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-ga4/bin/activate
             source /usr/local/share/virtualenvs/dev_env.sh
-            pip install nose coverage
-            nosetests --with-coverage --cover-erase --cover-package=tap_ga4 --cover-html-dir=htmlcov tests/unittests
-            coverage html
+            pip install nose2
+            nose2 -v -s tests/unittests
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.1.0
+  * Update libraries to run on python 3.11.7 [#99](https://github.com/singer-io/tap-ga4/pull/99)
 ## v0.0.32
   * Update cached field exclusions to match changes made in the GA4 Data API [#97](https://github.com/singer-io/tap-ga4/pull/97)
 ## v0.0.31

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.0.32",
+    version="0.1.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(
     py_modules=["tap_ga4"],
     install_requires=[
         "google-analytics-data==0.14.0",
-        "singer-python==5.12.2",
+        "singer-python==6.0.0",
         "requests==2.28.1",
-        "backoff==1.8.0",
+        "backoff==2.2.1",
     ],
     extras_require={
         'dev': [

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -8,7 +8,7 @@ from base import GA4Base
 class GA4PaginationTest(PaginationTest, GA4Base):
     """GA4 pagination test implementation """
 
-    start_date = GA4Base.timedelta_formatted(dt.now(), delta=timedelta(days=-300))
+    start_date = GA4Base.timedelta_formatted(dt.now(), delta=timedelta(days=-330))
     request_window_size = 100
 
     @staticmethod


### PR DESCRIPTION
# Description of change
Necessary changes to requirements and testing config to run on python 3.11.7
# Manual QA steps
 - 
 
# Risks
 - code not covered by tests could have incompatibilities with python 3.11 that we would not catch until released to prod
 
# Rollback steps
 - revert this branch
