### PR TITLE
Fixes 400 Cannot have filter_partition dimension without specifying filter-partitions in the request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## v0.1.5
-  * Fix `400 Cannot have filter_partition dimension without specifying filter-partitions in the request` error [#102](https://github.com/singer-io/tap-ga4/pull/104)
+  * Fix `400 Cannot have filter_partition dimension without specifying filter-partitions in the request` error [#104](https://github.com/singer-io/tap-ga4/pull/104)
 
 ## v0.1.4
   * Add `NUMBER` data type in the catalog for the `INTEGER` type metric field. [#102](https://github.com/singer-io/tap-ga4/pull/102)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.1.5
+  * Fix `400 Cannot have filter_partition dimension without specifying filter-partitions in the request` error [#102](https://github.com/singer-io/tap-ga4/pull/104)
 
 ## v0.1.4
   * Add `NUMBER` data type in the catalog for the `INTEGER` type metric field. [#102](https://github.com/singer-io/tap-ga4/pull/102)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.1.4",
+    version="0.1.5",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/field_exclusions.json
+++ b/tap_ga4/field_exclusions.json
@@ -1,4 +1,5 @@
 {
+    "comparison":[],
     "achievementId": [
         "cohortNthDay",
         "cohortNthMonth",


### PR DESCRIPTION
# Description of change
- Updated field exclusions list due to issue with getting exclusions for `comparison` dimension

[Error details](https://github.com/googleapis/google-cloud-python/issues/12697)

```python
  File "/opt/code/tap-ga4/tap_ga4/client.py", line 114, in check_dimension_compatibility
    return self._make_request(request)
  File "/usr/local/share/virtualenvs/tap-ga4/lib/python3.8/site-packages/backoff/_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
  File "/opt/code/tap-ga4/tap_ga4/client.py", line 51, in _make_request
    return self.client.check_compatibility(request)
lib/python3.8/site-packages/google/analytics/data_v1beta/services/beta_analytics_data/client.py", line 1353, in check_compatibility
    response = rpc(
  File "/usr/local/share/virtualenvs/tap-ga4/lib/python3.8/site-packages/google/api_core/gapic_v1/method.py", line 113, in __call__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/share/virtualenvs/tap-ga4/lib/python3.8/site-packages/google/api_core/timeout.py", line 120, in func_with_timeout
    return func(*args, **kwargs)
  File "/usr/local/share/virtualenvs/tap-ga4/lib/python3.8/site-packages/google/api_core/grpc_helpers.py", line 74, in error_remapped_callable
    raise exceptions.from_grpc_error(exc) from exc
google.api_core.exceptions.InvalidArgument: 400 Cannot have filter_partition dimension without specifying filter-partitions in the request.
```


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
