### PR TITLE
Make report_definitions optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v0.3.0
+  * Make `report_definitions` config property optional [#109](https://github.com/singer-io/tap-ga4/pull/109)
+
 ## v0.2.0
   * Allow `report_definitions` config property to be input as a list or json-encoded string [#107](https://github.com/singer-io/tap-ga4/pull/107)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.2.0",
+    version="0.3.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/__init__.py
+++ b/tap_ga4/__init__.py
@@ -15,12 +15,11 @@ REQUIRED_CONFIG_KEYS = [
     "refresh_token",
     "property_id",
     "account_id",
-    "report_definitions",
 ]
 
 def maybe_parse_report_definitions(config):
     """Converts report_definitions into a list if it is a JSON-encoded string."""
-    if isinstance(config["report_definitions"], str):
+    if isinstance(config.get("report_definitions", []), str):
         try:
             config.update(report_definitions = json.loads(config["report_definitions"]))
         except json.JSONDecodeError as e:
@@ -39,7 +38,7 @@ def main_impl():
     if args.state:
         state.update(args.state)
     if args.discover:
-        discover(client, config["report_definitions"], config["property_id"])
+        discover(client, config.get("report_definitions", []), config["property_id"])
         LOGGER.info("Discovery complete")
     elif args.catalog:
         sync(client, config, catalog, state)

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -12,6 +12,8 @@ class TestMaybeParseReportDefinitions(unittest.TestCase):
                           "[{\"name\":\"report1\",\"id\":\"id1\"},{\"name\":\"report2\",\"id\":\"id2\"}]",
                           'start_date': '2024-02-24T00:00:00Z',}
 
+    config_without_report_definitions = {'start_date': '2024-02-24T00:00:00Z'}
+
     config_with_bad_type = {'report_definitions':
                             12345,
                             'start_date': '2024-02-24T00:00:00Z',}
@@ -30,6 +32,13 @@ class TestMaybeParseReportDefinitions(unittest.TestCase):
         self.assertIsInstance(self.config_with_string["report_definitions"], list)
         self.assertEqual(self.config_with_string["start_date"], '2024-02-24T00:00:00Z')
         self.assertEqual(self.config_with_string, self.config_with_list)
+
+    def test_without_report_definitions(self):
+        """Test that config without report_definitions does not break"""
+        assert "report_definitions" not in self.config_without_report_definitions
+        maybe_parse_report_definitions(self.config_without_report_definitions)
+        assert "report_definitions" not in self.config_without_report_definitions
+        self.assertEqual(self.config_without_report_definitions["start_date"], '2024-02-24T00:00:00Z')
 
     def test_with_bad_type(self):
         """Test that config with report_definitions with unexpected type is unchanged by the function"""


### PR DESCRIPTION
# Description of change
`report_definitions` is not a required property of the config, and the tap can function with running pre-made reports. 

# Manual QA steps
 - We deleted `report_definitions` and ran a sync job locally to verify that removing the property from the required keys does not break anything.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
