### PR TITLE
Update premade reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v0.3.1
+  * Update deprecated metrics in premade reports [#110](https://github.com/singer-io/tap-ga4/pull/110)
+
 ## v0.3.0
   * Make `report_definitions` config property optional [#109](https://github.com/singer-io/tap-ga4/pull/109)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.3.0",
+    version="0.3.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/client.py
+++ b/tap_ga4/client.py
@@ -119,7 +119,7 @@ class Client:
         if report_name == "conversions_report":
             return FilterExpression(
                 filter=Filter(
-                    field_name="isConversionEvent",
+                    field_name="isKeyEvent",
                     string_filter=Filter.StringFilter(value="true")
                 )
             )

--- a/tap_ga4/reports.py
+++ b/tap_ga4/reports.py
@@ -6,7 +6,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -23,7 +23,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -40,7 +40,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -57,7 +57,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -74,7 +74,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -91,7 +91,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -108,7 +108,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -125,7 +125,7 @@ PREMADE_REPORTS = [
             "engagedSessions",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "totalUsers",
             "userEngagementDuration",
@@ -144,7 +144,7 @@ PREMADE_REPORTS = [
             "eventsPerSession",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -162,7 +162,7 @@ PREMADE_REPORTS = [
             "eventsPerSession",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -180,7 +180,7 @@ PREMADE_REPORTS = [
             "eventsPerSession",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -198,7 +198,7 @@ PREMADE_REPORTS = [
             "eventsPerSession",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -216,7 +216,7 @@ PREMADE_REPORTS = [
             "eventsPerSession",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -234,7 +234,7 @@ PREMADE_REPORTS = [
             "eventsPerSession",
             "engagementRate",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -259,7 +259,7 @@ PREMADE_REPORTS = [
     {
         "name": "conversions_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "totalUsers",
             "totalRevenue",
         ],
@@ -275,7 +275,7 @@ PREMADE_REPORTS = [
             "totalUsers",
             "newUsers",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -291,7 +291,7 @@ PREMADE_REPORTS = [
             "totalUsers",
             "newUsers",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -307,7 +307,7 @@ PREMADE_REPORTS = [
             "totalUsers",
             "newUsers",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -323,7 +323,7 @@ PREMADE_REPORTS = [
             "totalUsers",
             "newUsers",
             "eventCount",
-            "conversions",
+            "keyEvents",
             "totalRevenue",
             "userEngagementDuration",
         ],
@@ -502,7 +502,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_country_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount"
@@ -519,7 +519,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_region_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -536,7 +536,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_city_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -553,7 +553,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_language_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -570,7 +570,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_age_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -587,7 +587,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_gender_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -604,7 +604,7 @@ PREMADE_REPORTS = [
     {
         "name": "demographic_interests_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -621,7 +621,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_browser_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -638,7 +638,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_device_category_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -655,7 +655,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_device_model_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -672,7 +672,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_screen_resolution_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -689,7 +689,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_app_version_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -706,7 +706,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_platform_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -723,7 +723,7 @@ PREMADE_REPORTS = [
         {
         "name": "tech_os_version_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -740,7 +740,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_platform_and_device_category_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -757,7 +757,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_operating_system_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",
@@ -774,7 +774,7 @@ PREMADE_REPORTS = [
     {
         "name": "tech_os_with_version_report",
         "metrics": [
-            "conversions",
+            "keyEvents",
             "engagedSessions",
             "engagementRate",
             "eventCount",

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -189,12 +189,9 @@ class GA4AllFieldsTest(AllFieldsTest, GA4Base):
     def test_all_streams_sync_records(self):
         pass
 
-    #TODO: Field selection is currently broken. Remove these skips once it has been fixed.
+    #TODO: Field selection is currently broken. Remove this skip to re-enable the test once it has been fixed.
     @unittest.skip("skip until fixed in: https://qlik-dev.atlassian.net/browse/TDL-27149")
     def setUp(self):
-        pass
-    @unittest.skip("skip until fixed in: https://qlik-dev.atlassian.net/browse/TDL-27149")
-    def test_all_fields_for_streams_are_replicated(self):
         pass
 
 #  TODO - Run failed, might have an issue with the way we expect data for some fields

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -189,6 +189,14 @@ class GA4AllFieldsTest(AllFieldsTest, GA4Base):
     def test_all_streams_sync_records(self):
         pass
 
+    #TODO: Field selection is currently broken. Remove these skips once it has been fixed.
+    @unittest.skip("skip until fixed in: https://qlik-dev.atlassian.net/browse/TDL-27149")
+    def setUp(self):
+        pass
+    @unittest.skip("skip until fixed in: https://qlik-dev.atlassian.net/browse/TDL-27149")
+    def test_all_fields_for_streams_are_replicated(self):
+        pass
+
 #  TODO - Run failed, might have an issue with the way we expect data for some fields
 #   https://jira.talendforge.org/browse/TDL-21467 is for the nth_hour field being other
 #   We should remove nth_hour from random selection until the bug is addressed.

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -159,6 +159,7 @@ class GA4AllFieldsTest(AllFieldsTest, GA4Base):
 
         self.assertTrue(synced_stream_names.issubset(expected_streams))
 
+    @unittest.skip("skip until fixed in: https://qlik-dev.atlassian.net/browse/TDL-27149")
     def test_all_fields_for_streams_are_replicated(self):
         for stream in self.streams_to_test():
             with self.subTest(stream=stream):
@@ -187,11 +188,6 @@ class GA4AllFieldsTest(AllFieldsTest, GA4Base):
 
     @unittest.skip("Random selection doesn't always sync records")
     def test_all_streams_sync_records(self):
-        pass
-
-    #TODO: Field selection is currently broken. Remove this skip to re-enable the test once it has been fixed.
-    @unittest.skip("skip until fixed in: https://qlik-dev.atlassian.net/browse/TDL-27149")
-    def setUp(self):
         pass
 
 #  TODO - Run failed, might have an issue with the way we expect data for some fields


### PR DESCRIPTION
# Description of change
Updates deprecated metric in the premade reports. 
- `conversions` metric is now `keyEvents` 
- In the filterExpression for conversions_report, `isConversionEvent` is now `isKeyEvent`

# Manual QA steps
 - Viewed `keyEvents` as part of table selection for a local connection
 
# Risks
 - In testing, we found no difference in `conversion_report` output when the filter used `isKeyEvent` or `isConversionEvent`. This is strange considering `isConversionEvent` has been deprecated. `isKeyEvent` requires users to interact with the Analytics Console to mark events as `key events`. Its possible some users will see a difference in their `conversion_report` records after this filter is updated. 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
