### PR TITLE
SAC-23687: Adding new logic to handle sync time

### DIFF
--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -66,25 +66,25 @@ class GA4InterruptedSyncTest(InterruptedSyncTest, GA4Base):
     def calculate_expected_sync_start_time(self, bookmark, stream, completed=True):
         """This method is only for streams that have bookmarks and a sync has been started"""
 
-        # BUG override bookmark to use final state vs manipulate_state allowing test to pass
-        if GA4InterruptedSyncTest.card_is_done is None:
-            jira_status = get_jira_status_category('TDL-23687')
-            GA4InterruptedSyncTest.card_is_done = jira_status == 'done'
-            self.assertFalse(GA4InterruptedSyncTest.card_is_done,
-                         msg="JIRA BUG has transitioned to Done, remove work around")
-        bookmark  = self.get_bookmark_value(self.resuming_sync_state, stream)
+        # # BUG override bookmark to use final state vs manipulate_state allowing test to pass
+        # if GA4InterruptedSyncTest.card_is_done is None:
+        #     jira_status = get_jira_status_category('TDL-23687')
+        #     GA4InterruptedSyncTest.card_is_done = jira_status == 'done'
+        #     self.assertFalse(GA4InterruptedSyncTest.card_is_done,
+        #                  msg="JIRA BUG has transitioned to Done, remove work around")
+        bookmark = self.get_bookmark_value(self.resuming_sync_state, stream)
+        start_date = self.parse_date(self.start_date)
 
-        # The lookback window should be used for all bookmarked streams
-        #   function inherited from tap_tester.base_case
-        stream_lookback = self.expected_lookback_window(stream)
+        if not bookmark:
+            return start_date
 
-        # Expect the sync to start where the last sync left off,
-        #   expect to go back a lookback for completed streams
-        #   but don't go back before the start date.
-        if self.expected_start_date_behavior(stream):
-            return max(
-                self.parse_date(bookmark) - stream_lookback,
-                self.parse_date(self.start_date))
-
-        # if we don't respect the start date
-        return self.parse_date(bookmark) - stream_lookback
+        bookmark = self.parse_date(bookmark)
+        conversion_window = int(self.get_properties().get('conversion_window', GA4Base.CONVERSION_WINDOW))
+        conversion_day = self.parse_date(
+            GA4Base.timedelta_formatted(
+                dt.utcnow(),
+                delta=timedelta(days=-conversion_window),
+                date_format=self.bookmark_format
+            )
+        )
+        return min(bookmark, max(start_date, conversion_day))

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime as dt, timedelta
+from datetime import datetime as dt, timedelta, timezone
 
 from base import GA4Base, get_jira_status_category
 from tap_tester.base_suite_tests.interrupted_sync_test import InterruptedSyncTest
@@ -82,7 +82,7 @@ class GA4InterruptedSyncTest(InterruptedSyncTest, GA4Base):
         conversion_window = int(self.get_properties().get('conversion_window', GA4Base.CONVERSION_WINDOW))
         conversion_day = self.parse_date(
             GA4Base.timedelta_formatted(
-                dt.utcnow(),
+                dt.now(timezone.utc),
                 delta=timedelta(days=-conversion_window),
                 date_format=self.bookmark_format
             )

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -80,11 +80,5 @@ class GA4InterruptedSyncTest(InterruptedSyncTest, GA4Base):
 
         bookmark = self.parse_date(bookmark)
         conversion_window = int(self.get_properties().get('conversion_window', GA4Base.CONVERSION_WINDOW))
-        conversion_day = self.parse_date(
-            GA4Base.timedelta_formatted(
-                dt.now(timezone.utc),
-                delta=timedelta(days=-conversion_window),
-                date_format=self.bookmark_format
-            )
-        )
+        conversion_day = dt.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=conversion_window)
         return min(bookmark, max(start_date, conversion_day))

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -66,12 +66,6 @@ class GA4InterruptedSyncTest(InterruptedSyncTest, GA4Base):
     def calculate_expected_sync_start_time(self, bookmark, stream, completed=True):
         """This method is only for streams that have bookmarks and a sync has been started"""
 
-        # # BUG override bookmark to use final state vs manipulate_state allowing test to pass
-        # if GA4InterruptedSyncTest.card_is_done is None:
-        #     jira_status = get_jira_status_category('TDL-23687')
-        #     GA4InterruptedSyncTest.card_is_done = jira_status == 'done'
-        #     self.assertFalse(GA4InterruptedSyncTest.card_is_done,
-        #                  msg="JIRA BUG has transitioned to Done, remove work around")
         bookmark = self.get_bookmark_value(self.resuming_sync_state, stream)
         start_date = self.parse_date(self.start_date)
 


### PR DESCRIPTION
# Description of change
JIRA: https://qlik-dev.atlassian.net/browse/SAC-23687

The new logic is added which is very similar to the tap's get repor date. Also used an import package timezone since the utcnow is outdated.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
