### PR TITLE
Handle 400 InvalidArgument during checkCompatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,8 @@ jobs:
           command: |
             echo "Committing to GitHub"
 
+            apt-get update && apt-get install -y git gawk
+
             # Setup
             git config user.email "stitchintegrationdev@talend.com"
             git config user.name "CircleCI Job"
@@ -130,8 +132,6 @@ jobs:
             wget https://github.com/cli/cli/releases/download/v2.23.0/gh_2.23.0_linux_amd64.tar.gz
             tar xf gh_2.23.0_linux_amd64.tar.gz
             cp /root/project/gh_2.23.0_linux_amd64/bin/gh /usr/local/bin/
-
-            apt install -y gawk
 
             bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
             # End Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0
+  * Handle 400 InvalidArgument during checkCompatibility [#126](https://github.com/singer-io/tap-ga4/pull/126)
+
 ## v0.3.6
   * Update `google-analytics-data` library from `0.14.0` to `0.20.0` [#122](https://github.com/singer-io/tap-ga4/pull/122)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga4",
-    version="0.3.6",
+    version="0.4.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_ga4/discover.py
+++ b/tap_ga4/discover.py
@@ -4,6 +4,7 @@ import json
 import re
 import os
 import singer
+from google.api_core.exceptions import InvalidArgument
 from singer import Catalog, CatalogEntry, Schema, metadata
 from singer.catalog import write_catalog
 from tap_ga4.reports import PREMADE_REPORTS
@@ -190,7 +191,12 @@ def get_field_exclusions(client, property_id, dimensions, metrics):
     for dimension in dimensions:
         if dimension.api_name in field_exclusions:
             continue
-        res = client.check_dimension_compatibility(property_id, dimension)
+        try:
+            res = client.check_dimension_compatibility(property_id, dimension)
+        except InvalidArgument as e:
+            field_exclusions[dimension.api_name] = []
+            LOGGER.warning("Skipping field exclusion check for dimension '%s': %s", dimension.api_name, e)
+            continue
         for field in res.dimension_compatibilities:
             field_exclusions[dimension.api_name].append(
                 field.dimension_metadata.api_name)
@@ -202,7 +208,12 @@ def get_field_exclusions(client, property_id, dimensions, metrics):
     for metric in metrics:
         if metric.api_name in field_exclusions:
             continue
-        res = client.check_metric_compatibility(property_id, metric)
+        try:
+            res = client.check_metric_compatibility(property_id, metric)
+        except InvalidArgument as e:
+            field_exclusions[metric.api_name] = []
+            LOGGER.warning("Skipping field exclusion check for metric '%s': %s", metric.api_name, e)
+            continue
         for field in res.dimension_compatibilities:
             field_exclusions[metric.api_name].append(field.dimension_metadata.api_name)
         for field in res.metric_compatibilities:

--- a/tap_ga4/field_exclusions.json
+++ b/tap_ga4/field_exclusions.json
@@ -375,6 +375,23 @@
         "organicGoogleSearchImpressions",
         "returnOnAdSpend"
     ],
+    "browserVersion": [
+        "cohortNthDay",
+        "cohortNthMonth",
+        "cohortNthWeek",
+        "advertiserAdClicks",
+        "advertiserAdCost",
+        "advertiserAdCostPerClick",
+        "advertiserAdCostPerKeyEvent",
+        "advertiserAdImpressions",
+        "cohortActiveUsers",
+        "cohortTotalUsers",
+        "organicGoogleSearchAveragePosition",
+        "organicGoogleSearchClicks",
+        "organicGoogleSearchClickThroughRate",
+        "organicGoogleSearchImpressions",
+        "returnOnAdSpend"
+    ],
     "campaignId": [
         "brandingInterest",
         "cohortNthDay",

--- a/tests/field_exclusions/test_field_exclusions.py
+++ b/tests/field_exclusions/test_field_exclusions.py
@@ -2,6 +2,7 @@ import json
 import os
 from collections import defaultdict
 import unittest
+from google.api_core.exceptions import InvalidArgument
 from tap_ga4.discover import get_dimensions_and_metrics
 from tap_ga4.client import Client
 
@@ -27,7 +28,11 @@ class TestFieldExclusions(unittest.TestCase):
             if dimension.api_name == "comparison":
                 fields[dimension.api_name] = []
             else:
-                res = client.check_dimension_compatibility(property_id, dimension)
+                try:
+                    res = client.check_dimension_compatibility(property_id, dimension)
+                except InvalidArgument:
+                    fields[dimension.api_name] = []
+                    continue
 
                 for field in res.dimension_compatibilities:
                     fields[dimension.api_name].append(field.dimension_metadata.api_name)
@@ -43,7 +48,11 @@ class TestFieldExclusions(unittest.TestCase):
                                    "organicGoogleSearchImpressions", "returnOnAdSpend", "organicGoogleSearchClicks"]:
                 fields[metric.api_name] = []
             else:
-                res = client.check_metric_compatibility(property_id, metric)
+                try:
+                    res = client.check_metric_compatibility(property_id, metric)
+                except InvalidArgument:
+                    fields[metric.api_name] = []
+                    continue
 
                 for field in res.dimension_compatibilities:
                     fields[metric.api_name].append(field.dimension_metadata.api_name)

--- a/tests/field_exclusions/test_field_exclusions.py
+++ b/tests/field_exclusions/test_field_exclusions.py
@@ -2,7 +2,6 @@ import json
 import os
 from collections import defaultdict
 import unittest
-from google.api_core.exceptions import InvalidArgument
 from tap_ga4.discover import get_dimensions_and_metrics
 from tap_ga4.client import Client
 
@@ -28,11 +27,7 @@ class TestFieldExclusions(unittest.TestCase):
             if dimension.api_name == "comparison":
                 fields[dimension.api_name] = []
             else:
-                try:
-                    res = client.check_dimension_compatibility(property_id, dimension)
-                except InvalidArgument:
-                    fields[dimension.api_name] = []
-                    continue
+                res = client.check_dimension_compatibility(property_id, dimension)
 
                 for field in res.dimension_compatibilities:
                     fields[dimension.api_name].append(field.dimension_metadata.api_name)
@@ -48,11 +43,7 @@ class TestFieldExclusions(unittest.TestCase):
                                    "organicGoogleSearchImpressions", "returnOnAdSpend", "organicGoogleSearchClicks"]:
                 fields[metric.api_name] = []
             else:
-                try:
-                    res = client.check_metric_compatibility(property_id, metric)
-                except InvalidArgument:
-                    fields[metric.api_name] = []
-                    continue
+                res = client.check_metric_compatibility(property_id, metric)
 
                 for field in res.dimension_compatibilities:
                     fields[metric.api_name].append(field.dimension_metadata.api_name)


### PR DESCRIPTION
# Description of change
Google [rolled out](https://developers.google.com/analytics/devguides/reporting/data/v1/changelog) a new Conversion Performance reporting feature on April 23, 2026 to select GA4 properties. New conversion-only metrics/dimensions now appear in getMetadata responses for enrolled properties. When the tap calls [checkCompatibility](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/checkCompatibility) on these fields during discovery, the GA4 API throws 400 InvalidArgument instead of returning a normal response — crashing the tap.

So as part of this PR, we have added logic to handle 400 InvalidArgument during checkCompatibility

**Note**: The checkCompatibility API returns InvalidArgument for certain fields. Since we cannot determine their actual compatibility with other fields, we default to an empty exclusion list (i.e., assume no known incompatibilities). 
We are maintaining field_exclusions.json for Standard (non-custom) fields. So, there is no risk for such standard fields.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
